### PR TITLE
Table styling to match darker theme.

### DIFF
--- a/resources/css/dark.css
+++ b/resources/css/dark.css
@@ -49,16 +49,17 @@ html, body {
 /************** Tables ****************/
 /**************************************/
 table {
-    background-color: #F1F5F8;
-    color: #1C3D5A;
+  background-color: #11152D;
+  color: #F8FAFC;
 }
 
-table tr, td, th {
-    border: 1px solid #3D4852;
+table tr, table td, table th {
+  border-width: 1px;
+  border-color: #272e56;
 }
 
-table tr:hover td:hover th:hover {
-    background-color: #3D4852;
+table tr:hover, table td:hover, table th:hover {
+  background-color: #1D2244;
 }
 
 /**************************************/


### PR DESCRIPTION
The table on dark-theme still had the same styling on the light-theme. Just some CSS changes to make it match better and easier on the eyes.

**OLD:**
![Screen Shot 2019-09-12 at 1 55 48 PM](https://user-images.githubusercontent.com/487798/64820454-45bdf180-d565-11e9-83ce-a119d488c829.png)

**NEW:**
![Screen Shot 2019-09-12 at 1 55 53 PM](https://user-images.githubusercontent.com/487798/64820455-45bdf180-d565-11e9-893c-b8d286bc738d.png)
