### PR TITLE
Change switch border to match navbar

### DIFF
--- a/resources/css/dark.css
+++ b/resources/css/dark.css
@@ -94,3 +94,10 @@ table tr:hover, table td:hover, table th:hover {
     border: none;
     background-color: var(--sidebar);
 }
+
+/**************************************/
+/*************** Switch **************/
+/**************************************/
+.switch-label {
+    border-color: var(--navbar);
+}


### PR DESCRIPTION
Fixes the border colour of the switch to match the dark theme.

**From**
![image](https://user-images.githubusercontent.com/31845045/97022048-8ef3b980-154b-11eb-957c-e956d5abc7be.png)

**To**
![image](https://user-images.githubusercontent.com/31845045/97022133-a92d9780-154b-11eb-8f07-3d0c5afd2bd8.png)
